### PR TITLE
Update dependency version to 1.1.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@
 
 ##### Gradle
 ```groovy
-compile 'com.kbeanie:multipicker:1.1.2@aar'
+compile 'com.kbeanie:multipicker:1.1.3@aar'
 ```
 
 ##### Maven
@@ -34,7 +34,7 @@ compile 'com.kbeanie:multipicker:1.1.2@aar'
 <dependency>
     <groupId>com.kbeanie</groupId>
     <artifactId>multipicker</artifactId>
-    <version>1.1.2</version>
+    <version>1.1.3</version>
 </dependency>
 ```
 


### PR DESCRIPTION
README doesn't show the last version while changelog does, which is confusing.