### PR TITLE
Possible fix for #146

### DIFF
--- a/multipicker/src/main/java/com/kbeanie/multipicker/core/ImagePickerImpl.java
+++ b/multipicker/src/main/java/com/kbeanie/multipicker/core/ImagePickerImpl.java
@@ -148,7 +148,6 @@ public abstract class ImagePickerImpl extends PickerManager {
             intent = new Intent(Intent.ACTION_GET_CONTENT);
         }
         intent.putExtra(Intent.EXTRA_LOCAL_ONLY, true);
-//        Intent intent = new Intent(Intent.ACTION_GET_CONTENT);
         intent.setType("image/*");
         if (extras != null) {
             intent.putExtras(extras);

--- a/multipicker/src/main/java/com/kbeanie/multipicker/core/ImagePickerImpl.java
+++ b/multipicker/src/main/java/com/kbeanie/multipicker/core/ImagePickerImpl.java
@@ -139,7 +139,16 @@ public abstract class ImagePickerImpl extends PickerManager {
     }
 
     protected String pickLocalImage() {
-        Intent intent = new Intent(Intent.ACTION_GET_CONTENT);
+        Intent intent;
+        if(Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT){
+            intent = new Intent(Intent.ACTION_OPEN_DOCUMENT);
+            intent.putExtra(Intent.EXTRA_ALLOW_MULTIPLE, false);
+            intent.addFlags(Intent.FLAG_GRANT_PERSISTABLE_URI_PERMISSION);
+        }else{
+            intent = new Intent(Intent.ACTION_GET_CONTENT);
+        }
+        intent.putExtra(Intent.EXTRA_LOCAL_ONLY, true);
+//        Intent intent = new Intent(Intent.ACTION_GET_CONTENT);
         intent.setType("image/*");
         if (extras != null) {
             intent.putExtras(extras);


### PR DESCRIPTION
Hi @coomar2841 ,

I have been using your library for a while. Ran into some issues when image picking on newer devices (specifically modern Samsung and Huawei devices).

It sounds similar to what was described in issue #146 

I forked your library and managed to resolve the issue for my project at least. I have created a PR for your reference in case you can use it for a future release.

One last note is that the only other change I needed to make was to ensure the data persisted after restarts. I did this by modifying the section in `onActivityResult` as follows:

```
if (requestCode == Picker.PICK_IMAGE_DEVICE) {
    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
        val takeFlags = data!!.getFlags() and Intent.FLAG_GRANT_READ_URI_PERMISSION
        val resolver = activity!!.contentResolver 
        resolver.takePersistableUriPermission(data.data, takeFlags)  //data  is the passed in intent
     }
     imagePicker.submit(data)
}
```
Please note my use case was just for single image selection, and overall might need some additional null checking. Hope this is useful to you/your users.

All the best and thanks for sharing your library with us. 

-Dieter

