### PR TITLE
Include junit as testImplementation

### DIFF
--- a/multipicker/build.gradle
+++ b/multipicker/build.gradle
@@ -115,6 +115,6 @@ gradle.taskGraph.whenReady { taskGraph ->
 
 dependencies {
     compileOnly 'androidx.appcompat:appcompat:1.0.0'
-    implementation 'junit:junit:4.13'
+    testImplementation 'junit:junit:4.13'
     implementation 'androidx.legacy:legacy-support-v4:1.0.0'
 }


### PR DESCRIPTION
this fixes #178
Otherwise including `multipicker` in the implementation will also include `junit` in the implementation (discouraged).

More information:
- https://docs.gradle.org/current/userguide/declaring_dependencies.html
- https://developer.android.com/training/testing/unit-testing/instrumented-unit-tests#setup